### PR TITLE
Fix error due to new use of coerce method

### DIFF
--- a/lib/rspec-virtus/matcher.rb
+++ b/lib/rspec-virtus/matcher.rb
@@ -44,7 +44,7 @@ module RSpec
       end
 
       def attribute_exists?
-        attribute != nil
+        !attribute.nil?
       end
 
       def type_correct?


### PR DESCRIPTION
This commit fixes failing specs. Closes #9

Failures were introduced by the new use of Ruby coerce method in
equalizer gem, according to the following commit:
- https://github.com/dkubb/equalizer/commit/0f13
